### PR TITLE
Rewrite SpotifyAudioSource

### DIFF
--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -52,7 +52,6 @@ namespace SpotifyAudioSource
         /// </summary>
         public SpotifyAudioSource()
         {
-            _checkSpotifyTimer.Interval = PollingInterval;
             _checkSpotifyTimer.AutoReset = false;
             _checkSpotifyTimer.Elapsed += CheckSpotifyTimerOnElapsed;
         }
@@ -157,6 +156,7 @@ namespace SpotifyAudioSource
 
                 _pollingInterval = value;
                 OnSettingChanged("Spotify Polling Interval");
+                UpdatePollingInterval();
             }
         }
 
@@ -492,7 +492,7 @@ namespace SpotifyAudioSource
                     await DeactivateAsync();
                     return null;
                 }
-                
+
                 Logger.Info("Tried to update Spotify Playback, but user has no internet connection.");
                 await Task.Delay(10000);
                 _retryAttempts++;
@@ -698,7 +698,7 @@ namespace SpotifyAudioSource
                 }
                 else
                 {
-                    _checkSpotifyTimer.Interval = 1000;
+                    _checkSpotifyTimer.Interval = PollingInterval;
                 }
 
                 var playback = await GetPlayback();
@@ -772,6 +772,13 @@ namespace SpotifyAudioSource
             {
                 Logger.Warn($"Something went wrong with player command [{caller}].");
             }
+        }
+    
+        private void UpdatePollingInterval()
+        {
+            _checkSpotifyTimer.Stop();
+            _checkSpotifyTimer.Interval = PollingInterval;
+            _checkSpotifyTimer.Start();
         }
     }
 }

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -36,6 +36,7 @@ namespace SpotifyAudioSource
         private string _clientSecret;
         private string _clientId;
         private string _refreshToken;
+        private int _pollingInterval = 1000;
         private bool _useProxy;
         private string _proxyHost;
         private int _localPort = 80;
@@ -51,6 +52,7 @@ namespace SpotifyAudioSource
         /// </summary>
         public SpotifyAudioSource()
         {
+            _checkSpotifyTimer.Interval = PollingInterval;
             _checkSpotifyTimer.AutoReset = false;
             _checkSpotifyTimer.Elapsed += CheckSpotifyTimerOnElapsed;
         }
@@ -136,6 +138,25 @@ namespace SpotifyAudioSource
 
                 _refreshToken = value;
                 OnSettingChanged("Spotify Refresh Token");
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Polling Interval.
+        /// </summary>
+        [AudioSourceSetting("Spotify Polling Interval")]
+        public int PollingInterval
+        {
+            get => _pollingInterval;
+            set
+            {
+                if (value == _pollingInterval)
+                {
+                    return;
+                }
+
+                _pollingInterval = value;
+                OnSettingChanged("Spotify Polling Interval");
             }
         }
 

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -290,6 +290,7 @@ namespace SpotifyAudioSource
 
             _checkSpotifyTimer.Stop();
             _currentItemId = null;
+            _currentTrackName = null;
             Logger.Debug("Spotify has been deactivated.");
 
             return Task.CompletedTask;

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -506,12 +506,6 @@ namespace SpotifyAudioSource
             catch (Exception e)
             {
                 Logger.Error(e);
-
-                // Currently commented to see if it is still necessary
-                // When there is an error, for unknown reasons, the client sometimes stops working properly
-                // i.e, it is unable to refresh the token properly. Recreate the client prevents this issue.
-                // await Task.Delay(TimeSpan.FromSeconds(5));
-                // _spotifyApi = CreateSpotifyClient(_spotifyApi.AccessToken, _spotifyApi.TokenType);
                 return null;
             }
         }

--- a/src/SpotifyAudioSource/SpotifyAudioSource.csproj
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.csproj
@@ -107,10 +107,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SpotifyAPI.Web">
-      <Version>4.2.1</Version>
+      <Version>6.2.0</Version>
     </PackageReference>
     <PackageReference Include="SpotifyAPI.Web.Auth">
-      <Version>4.2.1</Version>
+      <Version>6.2.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>


### PR DESCRIPTION
## Summary
This updates the version of the SpotifyAPI-NET library to latest, requiring an entire rewrite.
Adds support for podcasts (episodes)

Optionally also add an alternative or easier way to authenticate with Spotify (the entire make an app thing is a bit of a hassle)
OR
Automate the process of going to the Dashboard, creating an application, adding the redirect url, and copy pasting the ClientId and ClientSecret to Audioband