### PR TITLE
Add initial time tooltip

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -5,3 +5,6 @@ dotnet_diagnostic.SA1413.severity = silent
 
 # SA1516: Elements should be separated by blank line
 dotnet_diagnostic.SA1516.severity = silent
+
+# SA1513: Closing brace should be followed by blank line
+dotnet_diagnostic.SA1513.severity = silent

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -2,3 +2,6 @@
 
 # SA1413: Use trailing comma in multi-line initializers
 dotnet_diagnostic.SA1413.severity = silent
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = silent

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Models\MouseBinding.cs" />
     <Compile Include="Models\MouseBindingCommandType.cs" />
     <Compile Include="Models\MouseInputType.cs" />
+    <Compile Include="Models\SliderToolTipType.cs" />
     <Compile Include="Models\UserProfile.cs" />
     <Compile Include="Models\SemanticVersion.cs" />
     <Compile Include="Settings\MappingProfiles\SettingsV1ToSettingsV2Profile.cs" />

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -131,6 +131,7 @@
     <Compile Include="UI\Behaviors\CanvasPositioning.cs" />
     <Compile Include="UI\Behaviors\Fallback.cs" />
     <Compile Include="UI\Behaviors\RedirectScrolling.cs" />
+    <Compile Include="UI\Behaviors\ShowTimeBehavior.cs" />
     <Compile Include="UI\Behaviors\SliderClickAndDrag.cs" />
     <Compile Include="UI\Behaviors\TrackOffsetFix.cs" />
     <Compile Include="Commands\AsyncRelayCommand.cs" />

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -132,7 +132,7 @@
     <Compile Include="UI\Behaviors\CanvasPositioning.cs" />
     <Compile Include="UI\Behaviors\Fallback.cs" />
     <Compile Include="UI\Behaviors\RedirectScrolling.cs" />
-    <Compile Include="UI\Behaviors\ShowTimeBehavior.cs" />
+    <Compile Include="UI\Behaviors\SliderToolTipBehavior.cs" />
     <Compile Include="UI\Behaviors\SliderClickAndDrag.cs" />
     <Compile Include="UI\Behaviors\TrackOffsetFix.cs" />
     <Compile Include="Commands\AsyncRelayCommand.cs" />

--- a/src/AudioBand/Models/SliderToolTipType.cs
+++ b/src/AudioBand/Models/SliderToolTipType.cs
@@ -1,0 +1,8 @@
+﻿namespace AudioBand.Models
+{
+    public enum SliderToolTipType
+    {
+        Volume = 0,
+        ProgressBar = 1,
+    }
+}

--- a/src/AudioBand/Models/SliderToolTipType.cs
+++ b/src/AudioBand/Models/SliderToolTipType.cs
@@ -1,8 +1,18 @@
 ﻿namespace AudioBand.Models
 {
+    /// <summary>
+    /// The Slider ToolTip Style.
+    /// </summary>
     public enum SliderToolTipType
     {
+        /// <summary>
+        /// The Volume Style.
+        /// </summary>
         Volume = 0,
+
+        /// <summary>
+        /// The ProgressBar style.
+        /// </summary>
         ProgressBar = 1,
     }
 }

--- a/src/AudioBand/UI/Behaviors/ShowTimeBehavior.cs
+++ b/src/AudioBand/UI/Behaviors/ShowTimeBehavior.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+
+namespace AudioBand.UI
+{
+    /// <summary>
+    /// Show time tooltip behavior for a slider.
+    /// </summary>
+    internal class ShowTimeBehavior : Behavior<Slider>
+    {
+        /// <summary>
+        /// Dependency property for <see cref="PrefixProperty"/>.
+        /// </summary>
+        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register(
+            "Prefix",
+            typeof(string),
+            typeof(ShowTimeBehavior),
+            new PropertyMetadata(default(string)));
+
+        private Track _track;
+
+        /// <summary>
+        /// Gets or sets the prefix
+        /// </summary>
+        public string Prefix
+        {
+            get
+            {
+                return (string)GetValue(PrefixProperty);
+            }
+            set
+            {
+                SetValue(PrefixProperty, value);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnAttached()
+        {
+            AssociatedObject.Loaded += AssociatedObjectOnLoaded;
+            base.OnAttached();
+        }
+
+        /// <inheritdoc />
+        protected override void OnDetaching()
+        {
+            _track.MouseMove -= TrackOnMouseMove;
+            _track = null;
+            base.OnDetaching();
+        }
+
+        private void AssociatedObjectOnLoaded(object sender, RoutedEventArgs routedEventArgs)
+        {
+            AssociatedObject.Loaded -= AssociatedObjectOnLoaded;
+            _track = (Track)AssociatedObject.Template.FindName("PART_Track", AssociatedObject);
+            _track.MouseMove += TrackOnMouseMove;
+        }
+
+        private void TrackOnMouseMove(object sender, MouseEventArgs mouseEventArgs)
+        {
+            var position = mouseEventArgs.GetPosition(_track);
+            var valueFromPoint = _track.ValueFromPoint(position);
+            var floorOfValueFromPoint = (int)Math.Floor(valueFromPoint);
+
+            var time = TimeSpan.FromMilliseconds(floorOfValueFromPoint);
+            var formattedTime = time.ToString("mm\\:ss");
+
+            if (time >= TimeSpan.FromHours(1))
+            {
+                formattedTime = time.ToString("hh\\:mm\\:ss");
+            }
+
+            var toolTip = $"{Prefix}{formattedTime}";
+            ToolTipService.SetToolTip(_track, toolTip);
+            ToolTipService.SetShowDuration(_track, 100000);
+        }
+    }
+}

--- a/src/AudioBand/UI/Behaviors/ShowTimeBehavior.cs
+++ b/src/AudioBand/UI/Behaviors/ShowTimeBehavior.cs
@@ -11,17 +11,17 @@ namespace AudioBand.UI
     /// <summary>
     /// Show time tooltip behavior for a slider.
     /// </summary>
-    internal class ShowTimeBehavior : Behavior<Slider>
+    internal class SliderTooltipBehavior : Behavior<Slider>
     {
         /// <summary>
         /// Dependency property for <see cref="PrefixProperty"/>.
         /// </summary>
-        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register("Prefix", typeof(string), typeof(ShowTimeBehavior), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register("Prefix", typeof(string), typeof(SliderTooltipBehavior), new PropertyMetadata(default(string)));
 
         /// <summary>
         /// Dependency property for <see cref="TypeProperty"/>
         /// </summary>
-        public static readonly DependencyProperty TypeProperty = DependencyProperty.Register("Type", typeof(SliderToolTipType), typeof(ShowTimeBehavior), new PropertyMetadata(SliderToolTipType.ProgressBar));
+        public static readonly DependencyProperty TypeProperty = DependencyProperty.Register("Type", typeof(SliderToolTipType), typeof(SliderTooltipBehavior), new PropertyMetadata(SliderToolTipType.ProgressBar));
 
         private Track _track;
 

--- a/src/AudioBand/UI/Behaviors/ShowTimeBehavior.cs
+++ b/src/AudioBand/UI/Behaviors/ShowTimeBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AudioBand.Models;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -15,27 +16,31 @@ namespace AudioBand.UI
         /// <summary>
         /// Dependency property for <see cref="PrefixProperty"/>.
         /// </summary>
-        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register(
-            "Prefix",
-            typeof(string),
-            typeof(ShowTimeBehavior),
-            new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register("Prefix", typeof(string), typeof(ShowTimeBehavior), new PropertyMetadata(default(string)));
+
+        /// <summary>
+        /// Dependency property for <see cref="TypeProperty"/>
+        /// </summary>
+        public static readonly DependencyProperty TypeProperty = DependencyProperty.Register("Type", typeof(SliderToolTipType), typeof(ShowTimeBehavior), new PropertyMetadata(SliderToolTipType.ProgressBar));
 
         private Track _track;
 
         /// <summary>
-        /// Gets or sets the prefix
+        /// Gets or sets the prefix.
         /// </summary>
         public string Prefix
         {
-            get
-            {
-                return (string)GetValue(PrefixProperty);
-            }
-            set
-            {
-                SetValue(PrefixProperty, value);
-            }
+            get => (string)GetValue(PrefixProperty);
+            set => SetValue(PrefixProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the Type.
+        /// </summary>
+        public SliderToolTipType Type
+        {
+            get => (SliderToolTipType)GetValue(TypeProperty);
+            set => SetValue(TypeProperty, value);
         }
 
         /// <inheritdoc />
@@ -66,15 +71,31 @@ namespace AudioBand.UI
             var valueFromPoint = _track.ValueFromPoint(position);
             var floorOfValueFromPoint = (int)Math.Floor(valueFromPoint);
 
-            var time = TimeSpan.FromMilliseconds(floorOfValueFromPoint);
-            var formattedTime = time.ToString("mm\\:ss");
+            var displayText = $"{Prefix}{floorOfValueFromPoint}";
 
-            if (time >= TimeSpan.FromHours(1))
+            switch (Type)
             {
-                formattedTime = time.ToString("hh\\:mm\\:ss");
+                case SliderToolTipType.ProgressBar:
+                    {
+                        var time = TimeSpan.FromMilliseconds(floorOfValueFromPoint);
+                        displayText = time.ToString("mm\\:ss");
+
+                        if (time >= TimeSpan.FromHours(1))
+                        {
+                            displayText = time.ToString("hh\\:mm\\:ss");
+                        }
+
+                        break;
+                    }
+                case SliderToolTipType.Volume:
+                    {
+                        break;
+                    }
+                default:
+                    break;
             }
 
-            var toolTip = $"{Prefix}{formattedTime}";
+            var toolTip = $"{Prefix}{displayText}";
             ToolTipService.SetToolTip(_track, toolTip);
             ToolTipService.SetShowDuration(_track, 100000);
         }

--- a/src/AudioBand/UI/Behaviors/SliderToolTipBehavior.cs
+++ b/src/AudioBand/UI/Behaviors/SliderToolTipBehavior.cs
@@ -11,17 +11,17 @@ namespace AudioBand.UI
     /// <summary>
     /// Show time tooltip behavior for a slider.
     /// </summary>
-    internal class SliderTooltipBehavior : Behavior<Slider>
+    internal class SliderToolTipBehavior : Behavior<Slider>
     {
         /// <summary>
         /// Dependency property for <see cref="PrefixProperty"/>.
         /// </summary>
-        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register("Prefix", typeof(string), typeof(SliderTooltipBehavior), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty PrefixProperty = DependencyProperty.Register("Prefix", typeof(string), typeof(SliderToolTipBehavior), new PropertyMetadata(default(string)));
 
         /// <summary>
         /// Dependency property for <see cref="TypeProperty"/>
         /// </summary>
-        public static readonly DependencyProperty TypeProperty = DependencyProperty.Register("Type", typeof(SliderToolTipType), typeof(SliderTooltipBehavior), new PropertyMetadata(SliderToolTipType.ProgressBar));
+        public static readonly DependencyProperty TypeProperty = DependencyProperty.Register("Type", typeof(SliderToolTipType), typeof(SliderToolTipBehavior), new PropertyMetadata(SliderToolTipType.ProgressBar));
 
         private Track _track;
 

--- a/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
+++ b/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
@@ -449,7 +449,7 @@
                         Value="{Binding Volume, Mode=TwoWay}">
                     <i:Interaction.Behaviors>
                         <audioband:SliderClickAndDrag />
-                        <audioband:SliderTooltipBehavior Prefix="" Type="Volume" />
+                        <audioband:SliderToolTipBehavior Prefix="" Type="Volume" />
                     </i:Interaction.Behaviors>
                     <Slider.Style>
                         <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource VolumeSliderStyle}">
@@ -480,7 +480,7 @@
             <i:Interaction.Behaviors>
                 <audioband:SliderThrottle FinalValue="{Binding TrackProgress, Converter={x:Static audioband:Converters.TimeSpanToMs}, Mode=TwoWay}" />
                 <audioband:SliderClickAndDrag />
-                <audioband:SliderTooltipBehavior Prefix="" Type="ProgressBar" />
+                <audioband:SliderToolTipBehavior Prefix="" Type="ProgressBar" />
             </i:Interaction.Behaviors>
             <Slider.Style>
                 <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource ProgressBarStyle}">

--- a/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
+++ b/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
@@ -479,6 +479,7 @@
             <i:Interaction.Behaviors>
                 <audioband:SliderThrottle FinalValue="{Binding TrackProgress, Converter={x:Static audioband:Converters.TimeSpanToMs}, Mode=TwoWay}" />
                 <audioband:SliderClickAndDrag />
+                <audioband:ShowTimeBehavior Prefix=""/>
             </i:Interaction.Behaviors>
             <Slider.Style>
                 <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource ProgressBarStyle}">

--- a/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
+++ b/src/AudioBand/UI/Toolbar/AudioBandToolbar.xaml
@@ -449,6 +449,7 @@
                         Value="{Binding Volume, Mode=TwoWay}">
                     <i:Interaction.Behaviors>
                         <audioband:SliderClickAndDrag />
+                        <audioband:SliderTooltipBehavior Prefix="" Type="Volume" />
                     </i:Interaction.Behaviors>
                     <Slider.Style>
                         <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource VolumeSliderStyle}">
@@ -479,7 +480,7 @@
             <i:Interaction.Behaviors>
                 <audioband:SliderThrottle FinalValue="{Binding TrackProgress, Converter={x:Static audioband:Converters.TimeSpanToMs}, Mode=TwoWay}" />
                 <audioband:SliderClickAndDrag />
-                <audioband:ShowTimeBehavior Prefix=""/>
+                <audioband:SliderTooltipBehavior Prefix="" Type="ProgressBar" />
             </i:Interaction.Behaviors>
             <Slider.Style>
                 <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource ProgressBarStyle}">


### PR DESCRIPTION
## Summary
Adds a little tooltip above the progress bar.
Current progress: 
![image](https://user-images.githubusercontent.com/35664724/184447212-536f9dce-6e74-4b41-ba22-2f82b8125253.png)

Currently crashes because it cant find the proper value for the volume bar

## Related Issue (if applicable)
Resolves #70 

## Checklist
- [x] Project Builds & Tests pass
- [x] These changes were tested out thoroughly
